### PR TITLE
Adds support for dynamic loading of RBuiltinNodes.

### DIFF
--- a/com.oracle.truffle.r.nodes.builtin/src/com/oracle/truffle/r/nodes/builtin/Extension.java
+++ b/com.oracle.truffle.r.nodes.builtin/src/com/oracle/truffle/r/nodes/builtin/Extension.java
@@ -1,0 +1,13 @@
+package com.oracle.truffle.r.nodes.builtin;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Interface for services, which provide {@link RBuiltinNode}'s that should loaded dynamically.
+ *
+ * See {@link RBuiltinPackages}
+ */
+public interface Extension {
+	Map<Class<?>, Supplier<RBuiltinNode>> entries();
+}

--- a/com.oracle.truffle.r.nodes.builtin/src/com/oracle/truffle/r/nodes/builtin/RBuiltinPackages.java
+++ b/com.oracle.truffle.r.nodes.builtin/src/com/oracle/truffle/r/nodes/builtin/RBuiltinPackages.java
@@ -28,6 +28,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.RootCallTarget;
@@ -67,6 +69,18 @@ public final class RBuiltinPackages implements RBuiltinLookup {
 
     public static RBuiltinPackages getInstance() {
         return instance;
+    }
+
+    /*
+     * Adds the RBuiltinNodes provided to the base package.
+     */
+    private static ServiceLoader<Extension> packages = ServiceLoader.load(Extension.class);
+    static {
+        for (Extension p : packages) {
+            for (Map.Entry<Class<?>, Supplier<RBuiltinNode>> e : p.entries().entrySet()) {
+                basePackage.add(e.getKey(), e.getValue());
+            }
+        }
     }
 
     public static void loadBase(MaterializedFrame baseFrame) {


### PR DESCRIPTION
In our project, which depends on fastR, we need to register RBuiltinNodes for our R functions. 
Currently, there is no way to add RBuiltinNodes to the `RBuiltinPackages`, but to to add them in the `BasePackage` class.

I added a ServiceLoader, which dynamically adds provided RBuiltinNodes via instances of the interface `Extension` to the base package. In the current status, there are no safety checks for overrides, etc.

I opened this PR as entry point for discussions and initial implementation, if dynamic loading of builtins seems like a valuable addition to fastR. 