### PR TITLE
mx build requires LLVM <= 8

### DIFF
--- a/documentation/dev/build-process.md
+++ b/documentation/dev/build-process.md
@@ -7,6 +7,7 @@ then delving into individual scripts that patch and build parts of GNUR. Last se
 
 ## `mx build`
 
+ * As of August 2018 requires LLVM <= 8
  * locates the module definition in `$(FASTR_R_HOME)/mx.fastr`
  * possibly loads the `env` file from `mx.fastr` (there is none, by default)
  * sets up binary suites, if any


### PR DESCRIPTION
`mx build` clones the `graal` repository and compiles `graal/sulong`, which requires LLVM <= 8. The LLVM included with macOS 10.12 says it is version 9, which is actually the XCode version. The problem is that the Clang bundled with macOS 10.12 does not support the flag `-disable-O0-optnone` and the compilation of Sulong fails. Upon installing LLVM 8 with Homebrew FastR can be compiled successfully.