### PR TITLE
Check if native-image is present. If not, install it.

### DIFF
--- a/com.oracle.truffle.r.native/run/install_r_native_image
+++ b/com.oracle.truffle.r.native/run/install_r_native_image
@@ -105,7 +105,13 @@ if [[ $verbose -eq 1 ]]; then
 fi
 
 log "Running: ../../../../bin/native-image" "${fastr_launcher_ni_args[@]}" -H:Name=RMain
-../../../../bin/native-image "${fastr_launcher_ni_args[@]}" -H:Name=RMain
+graalvm_home="../../../../bin"
+native_image=$graalvm_home/native-image
+if [ ! -f "$native_image" ]; then
+    echo "native-image was not found. It can be installed executing \`$graalvm_home/gu install native-image\`"
+    exit
+fi
+$native_image "${fastr_launcher_ni_args[@]}" -H:Name=RMain
 
 log "Creating backup of the R and Rscript launchers"
 cp "exec/R" "exec_R.backup"


### PR DESCRIPTION
`native-image`is no longer included with GraalVM CE and must be manually installed.
The Bash script that generates the FastR native image now checks for the presence of `native-image` and installs it if necessary.