### PR TITLE
Fix Cdist - Preserve dimensions when casting a vector to double

### DIFF
--- a/com.oracle.truffle.r.library/src/com/oracle/truffle/r/library/stats/Cdist.java
+++ b/com.oracle.truffle.r.library/src/com/oracle/truffle/r/library/stats/Cdist.java
@@ -52,7 +52,7 @@ public abstract class Cdist extends RExternalBuiltinNode.Arg4 {
 
     static {
         Casts casts = new Casts(Cdist.class);
-        casts.arg(0).mustBe(nullValue().not(), RError.Message.VECTOR_IS_TOO_LARGE).mustBe(missingValue().not()).asDoubleVector();
+        casts.arg(0).mustBe(nullValue().not(), RError.Message.VECTOR_IS_TOO_LARGE).mustBe(missingValue().not()).asDoubleVector(true,true,true);
         casts.arg(1).asIntegerVector().findFirst();
         casts.arg(2).mustBe(instanceOf(RList.class));
         casts.arg(3).asDoubleVector().findFirst();
@@ -68,7 +68,7 @@ public abstract class Cdist extends RExternalBuiltinNode.Arg4 {
                     @Cached("create()") GetDimAttributeNode getDimNode) {
         if (!getDimNode.isMatrix(x)) {
             // Note: otherwise array index out of bounds
-            throw error(Message.MUST_BE_SQUARE_MATRIX, "x");
+            throw error(Message.NON_MATRIX, "dist");
         }
         int nr = getDimNode.nrows(x);
         int nc = getDimNode.ncols(x);


### PR DESCRIPTION
Using FastR release 19.2.0.1 the following code

```R
m <- matrix(c(1L,2L,3L,4L,5L,6L), nrow=3, ncol=2)
dist(m)
```
results in `Error: 'x' must be a square matrix`.

The R function `dist` calls the C function `Cdist` defined in [stats/src/distance.c](https://github.com/wch/r-source/blob/trunk/src/library/stats/src/distance.c#L273). This function does not check whether its first argument is a matrix, but it checks the type of its elements:

```C
if(TYPEOF(x) != REALSXP) x = coerceVector(x, REALSXP);
```

FastR [implements](https://github.com/oracle/fastr/blob/master/com.oracle.truffle.r.library/src/com/oracle/truffle/r/library/stats/Cdist.java#L62) the Java function `Cdist`,  which checks whether its first argument is a matrix--not a square matrix--and if the test fails it throws

```Java
error(Message.MUST_BE_SQUARE_MATRIX, "x")
```

Throwing this error is wrong, because it does not correspond to the test that failed and because  R's `Cdist` works for rectangular matrices. The `Message` enum is defined in [RError.java](https://github.com/oracle/fastr/blob/284678c8e0f556c2a85274e202e93abec8498f5b/com.oracle.truffle.r.runtime/src/com/oracle/truffle/r/runtime/RError.java#L373).

The problem is that the argument `x` is casted to double without preserving its dimensions, resulting in a 1D vector. This patch corrects this.

To try it `make clean` in `com.oracle.truffle.r.native` and run `mx build`on the project root.

I suspect that this mistake in casting vectors to double without preserving their dimensions occurs in other places in FastR.