### PR TITLE
Implement INTEGER, REAL, RAW, LOGICAL, COMPLEX, R_CHAR upcalls as nodes

### DIFF
--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/COMPLEXNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/COMPLEXNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.r.runtime.data.RComplexVector;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class COMPLEXNode extends FFIUpCallNode.Arg1 {
+
+    public static COMPLEXNode create() {
+        return COMPLEXNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForComplexVector(RComplexVector complexVec,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(complexVec);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/FASTR_DATAPTRNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/FASTR_DATAPTRNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.r.runtime.data.RList;
+import com.oracle.truffle.r.runtime.data.RStringVector;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class FASTR_DATAPTRNode extends FFIUpCallNode.Arg1 {
+    public static FASTR_DATAPTRNode create() {
+        return FASTR_DATAPTRNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForStringVector(RStringVector stringVector,
+                    @Cached ConditionProfile isNativized,
+                    @Cached ConditionProfile needsWrapping,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        stringVector.wrapStrings(isNativized, needsWrapping);
+        return getObjectDataPtrNode.execute(stringVector);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForList(RList list,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(list);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/INTEGERNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/INTEGERNode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.data.RStringVector;
+import com.oracle.truffle.r.runtime.data.model.RAbstractAtomicVector;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class INTEGERNode extends FFIUpCallNode.Arg1 {
+
+    public static INTEGERNode create() {
+        return INTEGERNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForAtomicVector(RAbstractAtomicVector atomicVector,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode,
+                    @Cached ConditionProfile isStringProfile,
+                    @Cached ConditionProfile isNativized,
+                    @Cached ConditionProfile needsWrapping) {
+        if (isStringProfile.profile(atomicVector instanceof RStringVector)) {
+            ((RStringVector) atomicVector).wrapStrings(isNativized, needsWrapping);
+        }
+        return getObjectDataPtrNode.execute(atomicVector);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/LOGICALNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/LOGICALNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.r.runtime.data.RLogicalVector;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class LOGICALNode extends FFIUpCallNode.Arg1 {
+
+    public static LOGICALNode create() {
+        return LOGICALNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForLogicalVector(RLogicalVector logicalVec,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(logicalVec);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/RAWNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/RAWNode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.data.RRawVector;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class RAWNode extends FFIUpCallNode.Arg1 {
+    public static RAWNode create() {
+        return RAWNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForRawVector(RRawVector rawVector,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rawVector);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/REALNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/REALNode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.data.RStringVector;
+import com.oracle.truffle.r.runtime.data.model.RAbstractAtomicVector;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class REALNode extends FFIUpCallNode.Arg1 {
+
+    public static REALNode create() {
+        return REALNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForStringVector(RStringVector stringVector,
+                    @Cached ConditionProfile isNativized,
+                    @Cached ConditionProfile needsWrapping,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        stringVector.wrapStrings(isNativized, needsWrapping);
+        return getObjectDataPtrNode.execute(stringVector);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForAtomicVector(RAbstractAtomicVector atomicVector,
+                    @Cached.Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(atomicVector);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/R_CHARNode.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/nodes/R_CHARNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.r.ffi.impl.nodes;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.r.runtime.data.CharSXPWrapper;
+import com.oracle.truffle.r.runtime.data.RNull;
+import com.oracle.truffle.r.runtime.ffi.RObjectDataPtr;
+
+@GenerateUncached
+public abstract class R_CHARNode extends FFIUpCallNode.Arg1 {
+    public static R_CHARNode create() {
+        return R_CHARNodeGen.create();
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForNull(RNull rNull,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(rNull);
+    }
+
+    @Specialization
+    protected RObjectDataPtr doForCharSXPWrapper(CharSXPWrapper charSXPWrapper,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(charSXPWrapper);
+    }
+}

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/FastRUpCalls.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/FastRUpCalls.java
@@ -22,7 +22,9 @@
  */
 package com.oracle.truffle.r.ffi.impl.upcalls;
 
+import com.oracle.truffle.r.ffi.impl.nodes.FASTR_DATAPTRNode;
 import com.oracle.truffle.r.ffi.processor.RFFICpointer;
+import com.oracle.truffle.r.ffi.processor.RFFIUpCallNode;
 
 /**
  * Up-calls specific to FastR used in FastR native code and not exported as part of any API.
@@ -49,5 +51,6 @@ public interface FastRUpCalls {
      * the underlying data such as {@link com.oracle.truffle.r.runtime.data.RStringVector}.
      */
     @RFFICpointer
+    @RFFIUpCallNode(FASTR_DATAPTRNode.class)
     Object FASTR_DATAPTR(Object x);
 }

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/FastRUpCalls.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/FastRUpCalls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/StdUpCallsRFFI.java
+++ b/com.oracle.truffle.r.ffi.impl/src/com/oracle/truffle/r/ffi/impl/upcalls/StdUpCallsRFFI.java
@@ -33,6 +33,7 @@ import com.oracle.truffle.r.ffi.impl.nodes.AttributesAccessNodes.GetAttrib;
 import com.oracle.truffle.r.ffi.impl.nodes.AttributesAccessNodes.RfSetAttribNode;
 import com.oracle.truffle.r.ffi.impl.nodes.AttributesAccessNodes.SetAttribNode;
 import com.oracle.truffle.r.ffi.impl.nodes.AttributesAccessNodes.TAG;
+import com.oracle.truffle.r.ffi.impl.nodes.COMPLEXNode;
 import com.oracle.truffle.r.ffi.impl.nodes.CoerceNodes.AsCharacterFactor;
 import com.oracle.truffle.r.ffi.impl.nodes.CoerceNodes.CoerceVectorNode;
 import com.oracle.truffle.r.ffi.impl.nodes.CoerceNodes.VectorToPairListNode;
@@ -45,7 +46,9 @@ import com.oracle.truffle.r.ffi.impl.nodes.DuplicateNodes.RfAnyDuplicated3;
 import com.oracle.truffle.r.ffi.impl.nodes.EnvNodes.LockBindingNode;
 import com.oracle.truffle.r.ffi.impl.nodes.EnvNodes.UnlockBindingNode;
 import com.oracle.truffle.r.ffi.impl.nodes.GetClassDefNode;
+import com.oracle.truffle.r.ffi.impl.nodes.INTEGERNode;
 import com.oracle.truffle.r.ffi.impl.nodes.IsObjectNode;
+import com.oracle.truffle.r.ffi.impl.nodes.LOGICALNode;
 import com.oracle.truffle.r.ffi.impl.nodes.ListAccessNodes.CAARNode;
 import com.oracle.truffle.r.ffi.impl.nodes.ListAccessNodes.CAD4RNode;
 import com.oracle.truffle.r.ffi.impl.nodes.ListAccessNodes.CADDDRNode;
@@ -70,10 +73,12 @@ import com.oracle.truffle.r.ffi.impl.nodes.MiscNodes.SET_TRUELENGTHNode;
 import com.oracle.truffle.r.ffi.impl.nodes.MiscNodes.SetObjectNode;
 import com.oracle.truffle.r.ffi.impl.nodes.MiscNodes.TRUELENGTHNode;
 import com.oracle.truffle.r.ffi.impl.nodes.NewCustomConnectionNode;
+import com.oracle.truffle.r.ffi.impl.nodes.RAWNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RForceAndCallNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RMakeExternalPtrNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RNCharNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RSetExternalPtrNode;
+import com.oracle.truffle.r.ffi.impl.nodes.R_CHARNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RandFunctionsNodes;
 import com.oracle.truffle.r.ffi.impl.nodes.RfAllocVectorNode;
 import com.oracle.truffle.r.ffi.impl.nodes.RfEvalNode;
@@ -299,18 +304,23 @@ public interface StdUpCallsRFFI {
     void SET_ATTRIB(Object target, Object attributes);
 
     @RFFICpointer
+    @RFFIUpCallNode(RAWNode.class)
     Object RAW(Object x);
 
     @RFFICpointer
+    @RFFIUpCallNode(LOGICALNode.class)
     Object LOGICAL(Object x);
 
     @RFFICpointer
+    @RFFIUpCallNode(INTEGERNode.class)
     Object INTEGER(Object x);
 
     @RFFICpointer
+    @RFFIUpCallNode(INTEGERNode.class)
     Object REAL(Object x);
 
     @RFFICpointer
+    @RFFIUpCallNode(COMPLEXNode.class)
     Object COMPLEX(Object x);
 
     Object STRING_ELT(@RFFIResultOwner Object x, long i);
@@ -527,6 +537,7 @@ public interface StdUpCallsRFFI {
     Object PRCODE(@RFFIResultOwner Object x);
 
     @RFFICpointer
+    @RFFIUpCallNode(R_CHARNode.class)
     Object R_CHAR(Object x);
 
     @RFFIUpCallNode(NewCustomConnectionNode.class)

--- a/com.oracle.truffle.r.runtime/src/com/oracle/truffle/r/runtime/ffi/CRFFIWrapVectorNode.java
+++ b/com.oracle.truffle.r.runtime/src/com/oracle/truffle/r/runtime/ffi/CRFFIWrapVectorNode.java
@@ -24,6 +24,7 @@ package com.oracle.truffle.r.runtime.ffi;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
@@ -32,8 +33,8 @@ import com.oracle.truffle.r.runtime.RInternalError;
 import com.oracle.truffle.r.runtime.RRuntime;
 import com.oracle.truffle.r.runtime.data.RBaseObject;
 import com.oracle.truffle.r.runtime.data.RStringVector;
-import com.oracle.truffle.r.runtime.ffi.interop.StringArrayWrapper;
 import com.oracle.truffle.r.runtime.data.model.RAbstractVector;
+import com.oracle.truffle.r.runtime.ffi.interop.StringArrayWrapper;
 
 public abstract class CRFFIWrapVectorNode extends Node {
 
@@ -61,13 +62,15 @@ public abstract class CRFFIWrapVectorNode extends Node {
     }
 
     @Specialization(guards = {"isTemporary(vector)", "!isStringVector(vector)"})
-    protected Object temporaryToNative(RAbstractVector vector) {
-        return RObjectDataPtr.get(vector);
+    protected Object temporaryToNative(RAbstractVector vector,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(vector);
     }
 
     @Specialization(guards = {"!isTemporary(vector)", "!isStringVector(vector)"})
-    protected Object nonTemporaryToNative(RAbstractVector vector) {
-        return RObjectDataPtr.get(vector.copy());
+    protected Object nonTemporaryToNative(RAbstractVector vector,
+                    @Shared("getObjectDataPtrNode") @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) {
+        return getObjectDataPtrNode.execute(vector.copy());
     }
 
     @Specialization

--- a/com.oracle.truffle.r.runtime/src/com/oracle/truffle/r/runtime/ffi/DLL.java
+++ b/com.oracle.truffle.r.runtime/src/com/oracle/truffle/r/runtime/ffi/DLL.java
@@ -292,7 +292,8 @@ public class DLL {
         @ExportMessage
         public Object readArrayElement(long idx,
                         @Cached("createBinaryProfile()") ConditionProfile prof1,
-                        @Cached("createBinaryProfile()") ConditionProfile prof2) throws InvalidArrayIndexException {
+                        @Cached("createBinaryProfile()") ConditionProfile prof2,
+                        @Cached RObjectDataPtr.GetObjectDataPtrNode getObjectDataPtrNode) throws InvalidArrayIndexException {
             CharSXPWrapper res;
             if (prof1.profile(idx == 0)) {
                 res = pathSXP;
@@ -301,7 +302,7 @@ public class DLL {
             } else {
                 throw InvalidArrayIndexException.create(idx);
             }
-            return RObjectDataPtr.get(res);
+            return getObjectDataPtrNode.execute(res);
         }
 
         private static DLLInfo create(String name, String path, boolean dynamicLookup, LibHandle handle, boolean addToList) {


### PR DESCRIPTION
Implement INTEGER, REAL, LOGICAL, etc. upcalls as nodes.

The code of these upcalls is no longer behind TruffleBoundary.