### PR TITLE
Allow spaces in paths when building gnur

### DIFF
--- a/com.oracle.truffle.r.native/gnur/Makefile.gnur
+++ b/com.oracle.truffle.r.native/gnur/Makefile.gnur
@@ -103,18 +103,18 @@ GNUR_HOME_BINARY_UNPACKED_PARENT := $(dir $(GNUR_HOME_BINARY_UNPACKED))
 ifdef BUILD_GNUR
 $(GNUR_HOME_BINARY_UNPACKED)/gnur.done:
 	echo Installing R-$(R_VERSION) into $(GNUR_HOME_BINARY_UNPACKED)
-	rm -rf $(GNUR_HOME_BINARY_UNPACKED)
-	mkdir -p $(GNUR_HOME_BINARY_UNPACKED_PARENT)
-	(cd $(GNUR_HOME_BINARY_UNPACKED_PARENT); tar xf R-$(R_VERSION).tar.gz)
-	(cd $(GNUR_HOME_BINARY_UNPACKED); ./configure --with-x=no --with-aqua=no $(RECPKGS) --enable-memory-profiling $(GNUR_CONFIG_FLAGS) > gnur_configure.log 2>&1; $(MAKE) -j > gnur_make.log 2>&1)
-	touch $(GNUR_HOME_BINARY_UNPACKED)/gnur.done
+	rm -rf "$(GNUR_HOME_BINARY_UNPACKED)"
+	mkdir -p "$(GNUR_HOME_BINARY_UNPACKED_PARENT)"
+	(cd "$(GNUR_HOME_BINARY_UNPACKED_PARENT)"; tar xf R-$(R_VERSION).tar.gz)
+	(cd "$(GNUR_HOME_BINARY_UNPACKED)"; ./configure --with-x=no --with-aqua=no $(RECPKGS) --enable-memory-profiling $(GNUR_CONFIG_FLAGS) > gnur_configure.log 2>&1; "$(MAKE)" -j > gnur_make.log 2>&1)
+	touch "$(GNUR_HOME_BINARY_UNPACKED)/gnur.done"
 else
 $(GNUR_HOME_BINARY_UNPACKED)/gnur.done:
 	echo Unpacking R-$(R_VERSION) into $(GNUR_HOME_BINARY_UNPACKED)
-	rm -rf $(GNUR_HOME_BINARY_UNPACKED)
-	mkdir -p $(GNUR_HOME_BINARY_UNPACKED_PARENT)
-	(cd $(GNUR_HOME_BINARY_UNPACKED_PARENT); tar xf R-$(R_VERSION).tar.gz)
-	touch $(GNUR_HOME_BINARY_UNPACKED)/gnur.done
+	rm -rf "$(GNUR_HOME_BINARY_UNPACKED)"
+	mkdir -p "$(GNUR_HOME_BINARY_UNPACKED_PARENT)"
+	(cd "$(GNUR_HOME_BINARY_UNPACKED_PARENT)"; tar xf R-$(R_VERSION).tar.gz)
+	touch "$(GNUR_HOME_BINARY_UNPACKED)/gnur.done"
 endif
 
 IN_FILES := $(patsubst %.in,%,$(abspath $(shell find $(PATCH) -name '*.in')))


### PR DESCRIPTION
Especially `$(MAKE)` was not escaped, so building gnur failed because the path to Xcode contained a space (had to download an older version of XCode and renamed the app to `XCode 11.5.app`).