### PR TITLE
Added linux-musl support

### DIFF
--- a/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
+++ b/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
@@ -1,0 +1,5 @@
+/* Used to avoid compiler error on musl due to missing header file */
+
+#if !defined(__linux__) || defined(__GLIBC__)
+#include_next "fpu_control.h"
+#endif

--- a/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
+++ b/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
@@ -1,5 +1,27 @@
-/* Used to avoid compiler error on musl due to missing header file */
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 3 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 
+/* Used to avoid compiler error on musl due to missing header file */
 #if !defined(__linux__) || defined(__GLIBC__)
 #include_next "fpu_control.h"
 #endif

--- a/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c
+++ b/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c
@@ -79,6 +79,11 @@ size_t Rf_ucstoutf8(char *s, const unsigned int wc) {
     return 0;
 }
 
+size_t mbtoucs(unsigned int *wc, const char *s, size_t n) {
+    unimplemented("mbtoucs");
+    return 0;
+}
+
 void setup_RdotApp(void) {
 	unimplemented("setup_RdotApp");
 }


### PR DESCRIPTION
Hi,
The only thing that prevents fastr from building on musl is the `#include "fpu_control.h"` line somewhere in libf2c sources. This header file is missing in musl. I'm adding this (effectively empty) header file as a patch to `f2c/libf2c-patch`