### PR TITLE
linux-musl follow-up: fixed #include and CFLAGS for libf2c

### DIFF
--- a/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
+++ b/com.oracle.truffle.r.native/f2c/libf2c-patch/fpu_control.h
@@ -23,5 +23,5 @@
 
 /* Used to avoid compiler error on musl due to missing header file */
 #if !defined(__linux__) || defined(__GLIBC__)
-#include_next "fpu_control.h"
+#include <fpu_control.h>
 #endif

--- a/com.oracle.truffle.r.native/f2c/libf2c-patch/makefile
+++ b/com.oracle.truffle.r.native/f2c/libf2c-patch/makefile
@@ -96,10 +96,10 @@ libf2c.so: $(OFILES)
 ### If your system lacks ranlib, you don't need it; see README.
 
 f77vers.o: f77vers.c
-	$(CC) -c f77vers.c
+	$(CC) -c $(CFLAGS) f77vers.c
 
 i77vers.o: i77vers.c
-	$(CC) -c i77vers.c
+	$(CC) -c $(CFLAGS) i77vers.c
 
 # To get an "f2c.h" for use with "f2c -C++", first "make hadd"
 hadd: f2c.h0 f2ch.add


### PR DESCRIPTION
This fixes the build failure introduced by #175 by removing the `#include_next` magic altogether.

Plus I've identified another issue (somehow only showing with a freshly created repo): `CFLAGS` were missing for a couple of source files in libf2c Makefile. This is fixed as well.