### PR TITLE
Add a reference to GraalVM features support matrix to the user's README file 

### DIFF
--- a/documentation/user/README.md
+++ b/documentation/user/README.md
@@ -10,7 +10,7 @@ GraalVM provides a GNU-compatible R runtime to run R programs directly or in the
 It can run R code at [unparalleled performance](Performance.md), and seamlessly [integrates with the GraalVM ecosystem](#graalvm-integration).
 The project name behind GraalVM's R runtime development is [FastR](https://github.com/oracle/fastr).
 
->Note: The GraalVM R runtime is currently considered experimental, and not available for Windows AMD64 and macOS AArch64 (Apple Silicon).
+>Note: The GraalVM R runtime is currently considered experimental, and not available for Windows AMD64 and macOS AArch64 (Apple Silicon). You can refer to the [features support matrix](https://www.graalvm.org/latest/docs/introduction/#features-support) in the official GraalVM documentation.
 
 ## Installing R
 
@@ -22,8 +22,6 @@ gu install r
 After this step, the `R` and `Rscript` launchers will become available in the `JAVA_HOME/bin` directory.
 
 The R language home directory, which will be further referenced as `$R_HOME`, is located in `languages/R`.
-
-Note: Please have in mind that FastR is not available for ARM64 processors yet.
 
 ## Prerequisites
 

--- a/documentation/user/README.md
+++ b/documentation/user/README.md
@@ -23,6 +23,8 @@ After this step, the `R` and `Rscript` launchers will become available in the `J
 
 The R language home directory, which will be further referenced as `$R_HOME`, is located in `languages/R`.
 
+Note: Please have in mind that FastR is not available for ARM64 processors yet.
+
 ## Prerequisites
 
 GraalVM's R runtime requires [zlib](https://zlib.net/) and the [OpenMP runtime library](https://www.openmp.org).
@@ -58,6 +60,7 @@ brew install gcc
 
 Note: If the `gfortran` executable is not on your system path, you will need to configure
 the full path to it in `$R_HOME/etc/Makeconf`, the `FC` variable.
+
 
 ### Search Paths for Packages
 The default R library location is within the GraalVM installation directory.

--- a/documentation/user/README.md
+++ b/documentation/user/README.md
@@ -61,7 +61,6 @@ brew install gcc
 Note: If the `gfortran` executable is not on your system path, you will need to configure
 the full path to it in `$R_HOME/etc/Makeconf`, the `FC` variable.
 
-
 ### Search Paths for Packages
 The default R library location is within the GraalVM installation directory.
 In order to allow installation of additional packages for users who do not have write access to the GraalVM installation directory, edit the `R_LIBS_USER` variable in the `$JAVA_HOME/etc/Renviron` file.


### PR DESCRIPTION
It took me a while to find out this information while configuring my local env so I added this small remark about it on user's README file. 